### PR TITLE
making the libsoldout headers private generates bunch of warning

### DIFF
--- a/MarkdownParser.podspec
+++ b/MarkdownParser.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MarkdownParser"
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.summary          = "private podspec used for MarkdownParser in the Clue app. originally by @danieleggert"
   s.homepage         = "https://helloclue.com/"
   s.license          = "Copyright 2016 BioWink GmbH, all rights reserved."
@@ -21,8 +21,6 @@ Pod::Spec.new do |s|
                    "Source/libsoldout/array.{h,c}", 
                    "Source/libsoldout/buffer.{h,c}", 
                    "Source/libsoldout/markdown.{h,c}", 
-
-  s.private_header_files = "Source/libsoldout/*.h"
 
   s.frameworks = "Foundation"
   s.module_name = "MarkdownParser"


### PR DESCRIPTION
let's revert that:
<img width="1250" alt="screen shot 2017-03-15 at 15 35 42" src="https://cloud.githubusercontent.com/assets/1594081/23953521/16c40f98-0995-11e7-970c-6e9ab3edaf38.png">
🙃 🙃 🙃 